### PR TITLE
Prevent segmentation fault

### DIFF
--- a/thread_safe_function_round_trip/node-api/index.js
+++ b/thread_safe_function_round_trip/node-api/index.js
@@ -1,13 +1,25 @@
 const bindings = require('bindings')('round_trip');
+var ok = true;
 
 bindings.startThread((item, thePrime) => {
   console.log('The prime: ' + thePrime);
 
   // Answer the call with a 90% probability of returning true somewhere between
-  // 200 and 400 ms from now.
+  // 200 and 400 ms from now. To prevent segmentation fault (see the output below),
+  // make sure we return false only once.
   setTimeout(() => {
-    const theAnswer = (Math.random() > 0.1);
+    const theAnswer = ok ? (Math.random() > 0.1) : true;
+    if (ok) ok = theAnswer;
     console.log(thePrime + ': answering with ' + theAnswer);
     bindings.registerReturnValue(item, theAnswer);
   }, Math.random() * 200 + 200);
 });
+/*
+The prime: 7919
+The prime: 17389
+The prime: 27449
+7919: answering with false
+17389: answering with true
+27449: answering with false
+Segmentation fault: 11
+*/ 


### PR DESCRIPTION
Dear Gabriel,

Thank you very much for this example! It is examples we can run that makes documentation useful to us. I have run into a segmentation fault when Javascript responded with **false** twice. So I made a trivial and unimportant fix. Feel free to ignore it... :)

Once again, thanks a lot for your great work! 👍 Cheers,
Alec
