### PR TITLE
crash-fix thread-safe function round trip example

### DIFF
--- a/thread_safe_function_round_trip/node-api/round_trip.c
+++ b/thread_safe_function_round_trip/node-api/round_trip.c
@@ -36,13 +36,20 @@ typedef struct {
 
 // This function is responsible for converting the native data coming in from
 // the secondary thread to JavaScript values, and for calling the JavaScript
-// function. It will also be called with `env` and `js_cb` set to NULL when
+// function. It may also be called with `env` and `js_cb` set to `NULL` when
 // Node.js is terminating and there are items coming in from the secondary
 // thread left to process. In that case, this function does nothing, since it is
 // the secondary thread that frees the items.
 static void CallJs(napi_env env, napi_value js_cb, void* context, void* data) {
   AddonData* addon_data = (AddonData*)context;
   napi_value constructor;
+
+  // The semantics of this example are such that, once the JavaScript returns
+  // `false`, the `ThreadItem` structures can no longer be accessed, because the
+  // thread terminates and frees them all. Thus, we record the instant when
+  // JavaScript returns `false` by setting `addon_data->js_accepts` to `false`
+  // in `RegisterReturnValue` below, and we use the value here to decide whether
+  // the data coming in from the secondary thread is stale or not.
   if (addon_data->js_accepts && !(env == NULL || js_cb == NULL)) {
     napi_value undefined, argv[2];
     // Retrieve the JavaScript `undefined` value. This will serve as the `this`
@@ -58,10 +65,11 @@ static void CallJs(napi_env env, napi_value js_cb, void* context, void* data) {
     // Construct a new instance of the JavaScript class to hold the native item.
     assert(napi_new_instance(env, constructor, 0, NULL, &argv[0]) == napi_ok);
 
-    // Associate the native item with the JavaScript object. We assume that the
-    // JavaScript side will eventually pass this JavaScript object back to us
-    // via RegisterReturnValue, which will allow the eventual deallocation of
-    // the native data. That's why we do not provide a finalizer here.
+    // Associate the native item with the newly constructed JavaScript object.
+    // We assume that the JavaScript side will eventually pass this JavaScript
+    // object back to us via `RegisterReturnValue`, which will allow the
+    // eventual deallocation of the native data. That's why we do not provide a
+    // finalizer here.
     assert(napi_wrap(env, argv[0], data, NULL, NULL, NULL) == napi_ok);
 
     // Convert the prime number to a number `napi_value` we can pass into
@@ -90,10 +98,11 @@ static void ThreadFinished(napi_env env, void* data, void* context) {
 // The secondary thread produces prime numbers using a very inefficient
 // algorithm and calls into JavaScript with every REPORT_EVERYth prime number.
 // After each call it checks whether any of the previous calls have produced a
-// return value, and, if so, whether that return value is false. A false return
-// value indicates that the JavaScript side is no longer interested in receiving
-// any values. On the JavaScript thread, this is marked in
-// `addon_data->js_accepts`. When set to false, the JavaScript thread will not
+// return value, and, if so, whether that return value is `false`. A `false`
+// return value indicates that the JavaScript side is no longer interested in
+// receiving any values and that the thread and the thread-safe function are to
+// be cleaned up. On the JavaScript thread, this is marked in
+// `addon_data->js_accepts`. When set to `false`, the JavaScript thread will not
 // access the thread items any further, so they can be safely deleted on this
 // thread.
 static void PrimeThread(void* data) {
@@ -117,7 +126,9 @@ static void PrimeThread(void* data) {
     // If we find a prime, and it is REPORT_EVERY primes away from the previous
     // prime we found, then we send it to JavaScript.
     if (idx_inner >= idx_outer && (++prime_count % REPORT_EVERY) == 0) {
-      // Create a new thread item and attach it to the list of items.
+      // Create a new thread item and attach it to the list of outstanding
+      // `ThreadItem` structures representing calls into JavaScript for which
+      // no return value has yet been established.
       current = memset(malloc(sizeof(*current)), 0, sizeof(*current));
       current->the_prime = idx_outer;
       current->call_has_returned = false;
@@ -150,22 +161,24 @@ static void PrimeThread(void* data) {
       uv_mutex_unlock(&(addon_data->check_status_mutex));
     }
 
-    // If a call has returned true, we free the data associated with it.
-    // Otherwise we terminate the thread by breaking out of the loop.
+    // Process a return value. Free the `ThreadItem` that returned it, and break
+    // out of the loop if the return value was `false`.
     if (returned != NULL) {
-      if (returned->return_value) {
-        free(returned);
-      } else {
+      // Save the return value to a local variable because we have to check it
+      // after having freed the structure wherein it is stored.
+      bool return_value = returned->return_value;
+      free(returned);
+      if (!return_value) {
         break;
       }
     }
   }
 
-  // Before terminating the thread we free the remaining queue items. CallJs
+  // Before terminating the thread we free the remaining queue items. `CallJs`
   // will be called with pointers to these items, perhaps after this thread has
-  // already freed them, but that's OK, because addon_data->js_accepts will
-  // certainly have been set to false, and so CallJs will not dereference the
-  // stale pointers.
+  // already freed them, but that's OK, because on the JavaScript thread
+  // `addon_data->js_accepts` will certainly have been set to `false`, and so
+  // `CallJs` will not dereference the stale pointers.
   for (current = first; current != NULL;) {
     previous = current;
     current = current->next;
@@ -178,14 +191,14 @@ static void PrimeThread(void* data) {
                                           napi_tsfn_release) == napi_ok);
 }
 
-// Binding that can be called from JavaScript to start the asynchronous prime
+// This binding can be called from JavaScript to start the asynchronous prime
 // generator.
 static napi_value StartThread(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value js_cb, work_name;
   AddonData* addon_data;
 
-  // The function accepts one parameter - the JavaScript callback function to
+  // The binding accepts one parameter - the JavaScript callback function to
   // call.
   assert(napi_get_cb_info(env,
                           info,
@@ -206,9 +219,9 @@ static napi_value StartThread(napi_env env, napi_callback_info info) {
                                  &work_name) == napi_ok);
 
   // The thread-safe function will be created with an unlimited queue and with
-  // an initial reference of thread count of 1. The secondary thread will
-  // release the thread-safe function, decreasing its thread count to 0, thereby
-  // setting off the process of cleaning up the thread-safe function.
+  // an initial thread count of 1. The secondary thread will release the
+  // thread-safe function, decreasing its thread count to 0, thereby setting off
+  // the process of cleaning up the thread-safe function.
   assert(napi_create_threadsafe_function(env,
                                          js_cb,
                                          NULL,
@@ -221,18 +234,20 @@ static napi_value StartThread(napi_env env, napi_callback_info info) {
                                          CallJs,
                                          &addon_data->tsfn) == napi_ok);
 
-  // Create the thread that will produce primes.
+  // Create the thread that will produce primes and that will call into
+  // JavaScript using the thread-safe function.
   assert(uv_thread_create(&(addon_data->the_thread), PrimeThread, addon_data) == 0);
 
   return NULL;
 }
 
 // We use a separate binding to register a return value for a given call into
-// JavaScript. This allows the JavaScript side to asynchronously determine the
-// return value.
+// JavaScript, represented by a `ThreadItem` object on both the JavaScript side
+// and the native side. This allows the JavaScript side to asynchronously
+// determine the return value.
 static napi_value RegisterReturnValue(napi_env env, napi_callback_info info) {
   // This function accepts two parameters:
-  // 1. The thread item passed into JavaScript via CallJs
+  // 1. The thread item passed into JavaScript via `CallJs`, and
   // 2. The desired return value.
   size_t argc = 2;
   napi_value argv[2];
@@ -249,6 +264,15 @@ static napi_value RegisterReturnValue(napi_env env, napi_callback_info info) {
                           NULL,
                           (void*)&addon_data) == napi_ok);
 
+  // If this function recorded a return value of `false` before, it means that
+  // the thread and the associated thread-safe function are shutting down. This,
+  // in turn means that the wrapped `ThreadItem` that was received in the first
+  // argument may also be stale. Our best strategy is to do nothing and return
+  // to JavaScript.
+  if (!addon_data->js_accepts) {
+    return NULL;
+  }
+
   assert(argc == 2 && "Exactly two arguments were received");
 
   // Retrieve the constructor for `ThreadItem` instances.
@@ -257,6 +281,8 @@ static napi_value RegisterReturnValue(napi_env env, napi_callback_info info) {
                                   &constructor) == napi_ok);
 
   // Make sure the first parameter is an instance of the `ThreadItem` class.
+  // This type check ensures that there *is* a pointer stored inside the
+  // JavaScript object, and that the pointer is to a `ThreadItem` structure.
   assert(napi_instanceof(env,
                          argv[0],
                          constructor,
@@ -283,9 +309,10 @@ static napi_value RegisterReturnValue(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
-// Constructor for instances of the ThreadItem class. This doesn't need to do
-// anything since all we want the class for is to be able to type-tag objects
-// that carry within them pointers to native ThreadItem structures.
+// Constructor for instances of the `ThreadItem` class. This doesn't need to do
+// anything since all we want the class for is to be able to type-check
+// JavaScript objects that carry within them a pointer to a native `ThreadItem`
+// structure.
 static napi_value ThreadItemConstructor(napi_env env, napi_callback_info info) {
   return NULL;
 }
@@ -299,8 +326,12 @@ static void addon_is_unloading(napi_env env, void* data, void* hint) {
 }
 
 // Initialize an instance of this addon. This function may be called multiple
-// times if Node.js is running on multiple threads, or if there are multiple
-// contexts.
+// times if multiple instances of Node.js are running on multiple threads, or if
+// there are multiple Node.js contexts running on the same thread. The return
+// value and the formal parameters in comments remind us that the function body
+// that follows, within which we initialize the addon, has available to it the
+// variables named in the formal parameters, and that it must return a
+// `napi_value`.
 /*napi_value*/ NAPI_MODULE_INIT(/*napi_env env, napi_value exports*/) {
   // Create the native data that will be associated with this instance of the
   // addon.
@@ -316,8 +347,8 @@ static void addon_is_unloading(napi_env env, void* data, void* hint) {
                    NULL,
                    NULL) == napi_ok);
 
-  // Initialize the various members of the AddonData associated with this addon
-  // instance.
+  // Initialize the various members of the `AddonData` associated with this
+  // addon instance.
   assert(uv_mutex_init(&(addon_data->check_status_mutex)) == 0);
 
   napi_value thread_item_class;
@@ -359,7 +390,6 @@ static void addon_is_unloading(napi_env env, void* data, void* hint) {
       addon_data
     }
   };
-
   assert(napi_define_properties(env,
                                 exports,
                                 sizeof(export_properties) /


### PR DESCRIPTION
Fixes an access-after-free and a memory leak.

Closes: https://github.com/gabrielschulhof/abi-stable-node-addon-examples/pull/1