### PR TITLE
Add the 'prime' property (with its getter) to the 'ThreadItem' item

### DIFF
--- a/thread_safe_function_round_trip/node-api/index.js
+++ b/thread_safe_function_round_trip/node-api/index.js
@@ -1,6 +1,7 @@
 const bindings = require('bindings')('round_trip');
 
-bindings.startThread((item, thePrime) => {
+bindings.startThread(item => {
+  const thePrime = item.prime;
   console.log('The prime: ' + thePrime);
 
   // Answer the call with a 90% probability of returning true somewhere between


### PR DESCRIPTION
Gabriel,

This PR basically reflects my learning curve with N-API, feel free to ignore it. I thought it would be fun to get rid of the second argument, 'thePrime', in the JavaScript callback. It was fun to add the getter to the 'prime' property of the 'item' argument - with no C++! So I thought I'd better share the fun with you, just in case...

Thanks again and cheers,
👍 